### PR TITLE
Copy matching only native libraries to dependent project

### DIFF
--- a/Secp256k1.Native.targets
+++ b/Secp256k1.Native.targets
@@ -1,32 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+      <RuntimeIdentifiers>win-x64;win-x86;osx-x64;linux-x64</RuntimeIdentifiers>
+    </PropertyGroup>    
   <ItemGroup Condition="'$(SkipSecp256k1NativeLibCopy)' != 'true'">
-
-    
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\secp256k1.dll">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(RuntimeIdentifier)'=='win-x64'">PreserveNewest</CopyToOutputDirectory>
       <Link>native\win-x64\secp256k1.dll</Link>
       <Visible>true</Visible>
       <Pack>false</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\secp256k1.dll">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(RuntimeIdentifier)'=='win-x86'">PreserveNewest</CopyToOutputDirectory>
       <Link>native\win-x86\secp256k1.dll</Link>
       <Visible>true</Visible>
       <Pack>false</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libsecp256k1.so">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(RuntimeIdentifier)'=='linux-x64'">PreserveNewest</CopyToOutputDirectory>
       <Link>native\linux-x64\libsecp256k1.so</Link>
       <Visible>true</Visible>
       <Pack>false</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libsecp256k1.dylib">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(RuntimeIdentifier)'=='osx-x64'">PreserveNewest</CopyToOutputDirectory>
       <Link>native\osx-x64\libsecp256k1.dylib</Link>
       <Visible>true</Visible>
       <Pack>false</Pack>


### PR DESCRIPTION
First,  let me explain an issue we have now. We have some project which has Secp256k1 as NuGet dependency. When we create a package for this project for some platform with smth like `dotnet publish --runtime linux-x64 SomeDependentProject,csproj` we get a `native` folder in resulting package with all versions of secp256k1 libraries in it (including win and osx versions). Install package become bigger than it could be.
 
This fix allows to copy only related native libraries to the dependant project install package (i.e. only linux-64 .so file for `dotnet publish --runtime linux-x64 SomeDependentProject.csproj`). It would be great if you could upgrade your NuGet package with this functionality. 

Tell me please if you don't like this solution,  I'll try to find some other way to not copy this files. Thank you.)